### PR TITLE
Update migrations - add contributors url

### DIFF
--- a/internal/db/migrations/1750328591_add_column_contributors_url.down.sql
+++ b/internal/db/migrations/1750328591_add_column_contributors_url.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE repositories DROP COLUMN contributors_url;

--- a/internal/db/migrations/1750328591_add_column_contributors_url.up.sql
+++ b/internal/db/migrations/1750328591_add_column_contributors_url.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE repositories ADD COLUMN contributors_url VARCHAR(255);
+
+UPDATE repositories SET contributors_url = '' WHERE contributors_url IS NULL;
+
+ALTER TABLE repositories ALTER COLUMN contributors_url SET NOT NULL;


### PR DESCRIPTION
Update migrations- need to add contributors_url in repository table to use the url later for fetching contributors.