### PR TITLE
Allow null contribution id for redeemed transactions

### DIFF
--- a/internal/db/migrations/1751016438_allow-null-contribution-id.down.sql
+++ b/internal/db/migrations/1751016438_allow-null-contribution-id.down.sql
@@ -1,0 +1,6 @@
+UPDATE transactions
+SET contribution_id = 0 
+WHERE contribution_id IS NULL;
+
+ALTER TABLE transactions
+ALTER COLUMN contribution_id SET NOT NULL;

--- a/internal/db/migrations/1751016438_allow-null-contribution-id.up.sql
+++ b/internal/db/migrations/1751016438_allow-null-contribution-id.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE transactions
+ALTER COLUMN contribution_id DROP NOT NULL;


### PR DESCRIPTION
Transactions table have redeemed and gained transactions. If a transaction is a redeemed one then it is not for a contribution.
Allow contribution id in transactions table. To allow null values wherever possible.