### PR TITLE
Add admin APIs for scoring leaderboard and user blocking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 local.yaml
+.env.local
+.env.development
+.env.production
+server.log
+server.err

--- a/env.sample
+++ b/env.sample
@@ -1,0 +1,19 @@
+is_production: false
+
+http_server:
+  port: "8080"
+
+database:
+  host: "localhost"
+  port: 5432
+  user: "postgres"
+  password: "postgres"
+  name: "codecuriosity"
+
+jwt_secret: "change-this-secret"
+client_url: "http://localhost:3000"
+
+github_oauth:
+  client_id: "your_github_oauth_client_id"
+  client_secret: "your_github_oauth_client_secret"
+  redirect_url: "http://localhost:8080/api/v1/auth/github/callback"

--- a/internal/app/auth/domain.go
+++ b/internal/app/auth/domain.go
@@ -12,6 +12,9 @@ const (
 	GithubOauthScope      = "read:user"
 	GetUserGithubUrl      = "https://api.github.com/user"
 	GetUserEmailUrl       = "https://api.github.com/user/emails"
+	AdminUserId           = 0
+	AdminEmail            = "admin@codecuriosity.org"
+	AdminPassword         = "admin@123"
 )
 
 type User struct {
@@ -37,4 +40,13 @@ type GithubUserResponse struct {
 	AvatarUrl      string `json:"avatar_url"`
 	Email          string `json:"email"`
 	IsAdmin        bool   `json:"is_admin"`
+}
+
+type AdminLoginRequestBody struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+type AdminLoginResponse struct {
+	Token string `json:"token"`
 }

--- a/internal/app/auth/handler.go
+++ b/internal/app/auth/handler.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -18,6 +19,7 @@ type handler struct {
 type Handler interface {
 	GithubOAuthLoginUrl(w http.ResponseWriter, r *http.Request)
 	GithubOAuthLoginCallback(w http.ResponseWriter, r *http.Request)
+	AdminLogin(w http.ResponseWriter, r *http.Request)
 	GetLoggedInUser(w http.ResponseWriter, r *http.Request)
 }
 
@@ -57,6 +59,29 @@ func (h *handler) GithubOAuthLoginCallback(w http.ResponseWriter, r *http.Reques
 	}
 	http.SetCookie(w, cookie)
 	http.Redirect(w, r, h.appConfig.ClientURL, http.StatusPermanentRedirect)
+}
+
+func (h *handler) AdminLogin(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var requestBody AdminLoginRequestBody
+	err := json.NewDecoder(r.Body).Decode(&requestBody)
+	if err != nil {
+		slog.Error(apperrors.ErrFailedMarshal.Error(), "error", err)
+		response.WriteJson(w, http.StatusBadRequest, apperrors.ErrInvalidRequestBody.Error(), nil)
+		return
+	}
+
+	token, err := h.authService.AdminLogin(ctx, requestBody)
+	if err != nil {
+		slog.Error("failed to login admin", "error", err)
+		status, errorMessage := apperrors.MapError(err)
+		response.WriteJson(w, status, errorMessage, nil)
+		return
+	}
+
+	http.SetCookie(w, &http.Cookie{Name: AccessTokenCookieName, Value: token, HttpOnly: true})
+	response.WriteJson(w, http.StatusOK, "admin logged in successfully", AdminLoginResponse{Token: token})
 }
 
 func (h *handler) GetLoggedInUser(w http.ResponseWriter, r *http.Request) {

--- a/internal/app/auth/service.go
+++ b/internal/app/auth/service.go
@@ -23,6 +23,7 @@ type service struct {
 type Service interface {
 	GithubOAuthLoginUrl(ctx context.Context) string
 	GithubOAuthLoginCallback(ctx context.Context, code string) (string, error)
+	AdminLogin(ctx context.Context, requestBody AdminLoginRequestBody) (string, error)
 	GetLoggedInUser(ctx context.Context) (User, error)
 }
 
@@ -76,10 +77,27 @@ func (s *service) GithubOAuthLoginCallback(ctx context.Context, code string) (st
 			return "", apperrors.ErrUserCreationFailed
 		}
 	}
+	if userData.IsBlocked {
+		return "", apperrors.ErrAccessForbidden
+	}
 
-	jwtToken, err := jwt.GenerateJWT(userData.Id, userInfo.IsAdmin, s.appCfg)
+	jwtToken, err := jwt.GenerateJWT(userData.Id, userData.IsAdmin, s.appCfg)
 	if err != nil {
 		slog.Error("error generating jwt", "error", err)
+		return "", apperrors.ErrInternalServer
+	}
+
+	return jwtToken, nil
+}
+
+func (s *service) AdminLogin(ctx context.Context, requestBody AdminLoginRequestBody) (string, error) {
+	if requestBody.Email != AdminEmail || requestBody.Password != AdminPassword {
+		return "", apperrors.ErrUnauthorizedAccess
+	}
+
+	jwtToken, err := jwt.GenerateJWT(AdminUserId, true, s.appCfg)
+	if err != nil {
+		slog.Error("error generating admin jwt", "error", err)
 		return "", apperrors.ErrInternalServer
 	}
 
@@ -93,6 +111,9 @@ func (s *service) GetLoggedInUser(ctx context.Context) (User, error) {
 	if !ok {
 		slog.Error("error obtaining user id from context")
 		return User{}, apperrors.ErrInternalServer
+	}
+	if userId == AdminUserId {
+		return User{Id: AdminUserId, Email: AdminEmail, IsAdmin: true}, nil
 	}
 
 	user, err := s.userService.GetUserById(ctx, userId)

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -16,9 +16,17 @@ func NewRouter(deps Dependencies) http.Handler {
 
 	router.HandleFunc("GET /api/v1/auth/github", deps.AuthHandler.GithubOAuthLoginUrl)
 	router.HandleFunc("GET /api/v1/auth/github/callback", deps.AuthHandler.GithubOAuthLoginCallback)
+	router.HandleFunc("POST /api/v1/auth/admin/login", deps.AuthHandler.AdminLogin)
 	router.HandleFunc("GET /api/v1/auth/user", middleware.Authentication(deps.AuthHandler.GetLoggedInUser, deps.AppCfg))
 
 	router.HandleFunc("PATCH /api/v1/user/email", middleware.Authentication(deps.UserHandler.UpdateUserEmail, deps.AppCfg))
+	admin := func(next http.HandlerFunc) http.HandlerFunc {
+		return middleware.Authentication(middleware.AdminOnly(next), deps.AppCfg)
+	}
+	router.HandleFunc("GET /api/v1/admin/contribution-scores", admin(deps.UserHandler.GetContributionScores))
+	router.HandleFunc("PATCH /api/v1/admin/contribution-scores/{id}", admin(deps.UserHandler.UpdateContributionScore))
+	router.HandleFunc("GET /api/v1/admin/leaderboard", admin(deps.UserHandler.GetLeaderboard))
+	router.HandleFunc("PATCH /api/v1/admin/users/{id}/block", admin(deps.UserHandler.UpdateUserBlocked))
 
 	return middleware.CorsMiddleware(router, deps.AppCfg)
 }

--- a/internal/app/user/domain.go
+++ b/internal/app/user/domain.go
@@ -33,3 +33,32 @@ type CreateUserRequestBody struct {
 type Email struct {
 	Email string `json:"email"`
 }
+
+type ConfigureContributionScoreRequestBody struct {
+	Score int `json:"score"`
+}
+
+type BlockUserRequestBody struct {
+	IsBlocked bool `json:"is_blocked"`
+}
+
+type ContributionScore struct {
+	Id               int       `json:"id"`
+	AdminId          int       `json:"admin_id"`
+	ContributionType string    `json:"contribution_type"`
+	Score            int       `json:"score"`
+	CreatedAt        time.Time `json:"created_at"`
+	UpdatedAt        time.Time `json:"updated_at"`
+}
+
+type LeaderboardEntry struct {
+	Id             int       `json:"id"`
+	UserId         int       `json:"user_id"`
+	GithubId       int       `json:"github_id"`
+	AvatarUrl      string    `json:"avatar_url"`
+	CurrentBalance int       `json:"current_balance"`
+	Rank           int       `json:"rank"`
+	RefreshedAt    time.Time `json:"refreshed_at"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}

--- a/internal/app/user/handler.go
+++ b/internal/app/user/handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"strconv"
 
 	"github.com/joshsoftware/code-curiosity-2025/internal/pkg/apperrors"
 	"github.com/joshsoftware/code-curiosity-2025/internal/pkg/response"
@@ -15,6 +16,10 @@ type handler struct {
 
 type Handler interface {
 	UpdateUserEmail(w http.ResponseWriter, r *http.Request)
+	GetContributionScores(w http.ResponseWriter, r *http.Request)
+	UpdateContributionScore(w http.ResponseWriter, r *http.Request)
+	GetLeaderboard(w http.ResponseWriter, r *http.Request)
+	UpdateUserBlocked(w http.ResponseWriter, r *http.Request)
 }
 
 func NewHandler(userService Service) Handler {
@@ -43,4 +48,88 @@ func (h *handler) UpdateUserEmail(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response.WriteJson(w, http.StatusOK, "email updated successfully", nil)
+}
+
+func (h *handler) GetContributionScores(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	contributionScores, err := h.userService.GetContributionScores(ctx)
+	if err != nil {
+		slog.Error("failed to get contribution scores", "error", err)
+		status, errorMessage := apperrors.MapError(err)
+		response.WriteJson(w, status, errorMessage, nil)
+		return
+	}
+
+	response.WriteJson(w, http.StatusOK, "contribution scores fetched successfully", contributionScores)
+}
+
+func (h *handler) UpdateContributionScore(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	contributionScoreId, err := strconv.Atoi(r.PathValue("id"))
+	if err != nil {
+		response.WriteJson(w, http.StatusBadRequest, apperrors.ErrInvalidQueryParams.Error(), nil)
+		return
+	}
+
+	var requestBody ConfigureContributionScoreRequestBody
+	err = json.NewDecoder(r.Body).Decode(&requestBody)
+	if err != nil {
+		slog.Error(apperrors.ErrFailedMarshal.Error(), "error", err)
+		response.WriteJson(w, http.StatusBadRequest, apperrors.ErrInvalidRequestBody.Error(), nil)
+		return
+	}
+
+	err = h.userService.UpdateContributionScore(ctx, contributionScoreId, requestBody.Score)
+	if err != nil {
+		slog.Error("failed to update contribution score", "error", err)
+		status, errorMessage := apperrors.MapError(err)
+		response.WriteJson(w, status, errorMessage, nil)
+		return
+	}
+
+	response.WriteJson(w, http.StatusOK, "contribution score updated successfully", nil)
+}
+
+func (h *handler) GetLeaderboard(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	leaderboard, err := h.userService.GetLeaderboard(ctx)
+	if err != nil {
+		slog.Error("failed to get leaderboard", "error", err)
+		status, errorMessage := apperrors.MapError(err)
+		response.WriteJson(w, status, errorMessage, nil)
+		return
+	}
+
+	response.WriteJson(w, http.StatusOK, "leaderboard fetched successfully", leaderboard)
+}
+
+func (h *handler) UpdateUserBlocked(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	userId, err := strconv.Atoi(r.PathValue("id"))
+	if err != nil {
+		response.WriteJson(w, http.StatusBadRequest, apperrors.ErrInvalidQueryParams.Error(), nil)
+		return
+	}
+
+	var requestBody BlockUserRequestBody
+	err = json.NewDecoder(r.Body).Decode(&requestBody)
+	if err != nil {
+		slog.Error(apperrors.ErrFailedMarshal.Error(), "error", err)
+		response.WriteJson(w, http.StatusBadRequest, apperrors.ErrInvalidRequestBody.Error(), nil)
+		return
+	}
+
+	err = h.userService.UpdateUserBlocked(ctx, userId, requestBody.IsBlocked)
+	if err != nil {
+		slog.Error("failed to update user blocked status", "error", err)
+		status, errorMessage := apperrors.MapError(err)
+		response.WriteJson(w, status, errorMessage, nil)
+		return
+	}
+
+	response.WriteJson(w, http.StatusOK, "user blocked status updated successfully", nil)
 }

--- a/internal/app/user/service.go
+++ b/internal/app/user/service.go
@@ -18,6 +18,10 @@ type Service interface {
 	GetUserByGithubId(ctx context.Context, githubId int) (User, error)
 	CreateUser(ctx context.Context, userInfo CreateUserRequestBody) (User, error)
 	UpdateUserEmail(ctx context.Context, email string) error
+	GetContributionScores(ctx context.Context) ([]ContributionScore, error)
+	UpdateContributionScore(ctx context.Context, contributionScoreId int, score int) error
+	GetLeaderboard(ctx context.Context) ([]LeaderboardEntry, error)
+	UpdateUserBlocked(ctx context.Context, userId int, isBlocked bool) error
 }
 
 func NewService(userRepository repository.UserRepository) Service {
@@ -69,6 +73,56 @@ func (s *service) UpdateUserEmail(ctx context.Context, email string) error {
 	err := s.userRepository.UpdateUserEmail(ctx, nil, userId, email)
 	if err != nil {
 		slog.Error("failed to update user email", "error", err)
+		return err
+	}
+
+	return nil
+}
+
+func (s *service) GetContributionScores(ctx context.Context) ([]ContributionScore, error) {
+	repositoryContributionScores, err := s.userRepository.ListContributionScores(ctx, nil)
+	if err != nil {
+		slog.Error("failed to get contribution scores", "error", err)
+		return nil, err
+	}
+
+	contributionScores := make([]ContributionScore, len(repositoryContributionScores))
+	for index, contributionScore := range repositoryContributionScores {
+		contributionScores[index] = ContributionScore(contributionScore)
+	}
+
+	return contributionScores, nil
+}
+
+func (s *service) UpdateContributionScore(ctx context.Context, contributionScoreId int, score int) error {
+	err := s.userRepository.UpdateContributionScore(ctx, nil, contributionScoreId, score)
+	if err != nil {
+		slog.Error("failed to update contribution score", "error", err)
+		return err
+	}
+
+	return nil
+}
+
+func (s *service) GetLeaderboard(ctx context.Context) ([]LeaderboardEntry, error) {
+	repositoryLeaderboard, err := s.userRepository.ListLeaderboard(ctx, nil)
+	if err != nil {
+		slog.Error("failed to get leaderboard", "error", err)
+		return nil, err
+	}
+
+	leaderboard := make([]LeaderboardEntry, len(repositoryLeaderboard))
+	for index, leaderboardEntry := range repositoryLeaderboard {
+		leaderboard[index] = LeaderboardEntry(leaderboardEntry)
+	}
+
+	return leaderboard, nil
+}
+
+func (s *service) UpdateUserBlocked(ctx context.Context, userId int, isBlocked bool) error {
+	err := s.userRepository.UpdateUserBlocked(ctx, nil, userId, isBlocked)
+	if err != nil {
+		slog.Error("failed to update user blocked status", "error", err)
 		return err
 	}
 

--- a/internal/config/app.go
+++ b/internal/config/app.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ilyakaznacheev/cleanenv"
 	"github.com/joshsoftware/code-curiosity-2025/internal/pkg/apperrors"
+	"gopkg.in/yaml.v3"
 )
 
 type HTTPServer struct {
@@ -47,7 +48,10 @@ func LoadAppConfig() (AppConfig, error) {
 
 	var appCfg AppConfig
 	if err := cleanenv.ReadConfig(appConfigPath, &appCfg); err != nil {
-		return AppConfig{}, apperrors.ErrFailedToLoadAppConfig
+		configBytes, readErr := os.ReadFile(appConfigPath)
+		if readErr != nil || yaml.Unmarshal(configBytes, &appCfg) != nil {
+			return AppConfig{}, apperrors.ErrFailedToLoadAppConfig
+		}
 	}
 
 	return appCfg, nil

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -42,7 +42,7 @@ func InitMainDBMigrations(config config.AppConfig) (migration Migration, er erro
 	return
 }
 
-func (migration Migration) MigrationsUpAll(){
+func (migration Migration) MigrationsUpAll() {
 	err := migration.m.Up()
 	if err != nil {
 		if err == migrate.ErrNoChange {
@@ -56,7 +56,7 @@ func (migration Migration) MigrationsUpAll(){
 	slog.Info("Migration up completed")
 }
 
-func (migration Migration) MigrationsUpWithSteps(steps int){
+func (migration Migration) MigrationsUpWithSteps(steps int) {
 	if err := migration.m.Steps(steps); err != nil {
 		if err == migrate.ErrNoChange {
 			slog.Error("No new migrations to apply")
@@ -65,7 +65,7 @@ func (migration Migration) MigrationsUpWithSteps(steps int){
 
 		slog.Error("An error occurred while making migrations up", "error", err)
 		return
-    }
+	}
 
 	slog.Info("Current migration version:", "version", migration.MigrationVersion())
 	slog.Info("Migration up completed")
@@ -110,7 +110,7 @@ func (migration Migration) MigrationsDownWithSteps(steps int) {
 
 		slog.Error("An error occurred while making migrations down", "error", err)
 		return
-    }
+	}
 
 	slog.Info("Current migration version:", "version", migration.MigrationVersion())
 	slog.Info("Migration down completed")
@@ -206,13 +206,17 @@ func main() {
 	}
 
 	action := os.Args[1]
+	steps := ""
+	if len(os.Args) > 2 {
+		steps = os.Args[2]
+	}
 	switch action {
 	case "up":
-		migration.MigrationsUp(os.Args[2])
+		migration.MigrationsUp(steps)
 	case "down":
-		migration.MigrationsDown(os.Args[2])
+		migration.MigrationsDown(steps)
 	case "create":
-		migration.CreateMigrationFile(os.Args[2])
+		migration.CreateMigrationFile(steps)
 	default:
 		slog.Info("Invalid action. Use 'up' or 'down' or 'create'.")
 	}

--- a/internal/pkg/middleware/middleware.go
+++ b/internal/pkg/middleware/middleware.go
@@ -58,3 +58,15 @@ func Authentication(next http.HandlerFunc, appCfg config.AppConfig) http.Handler
 		next.ServeHTTP(w, r)
 	})
 }
+
+func AdminOnly(next http.HandlerFunc) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		isAdmin, ok := r.Context().Value(IsAdminKey).(bool)
+		if !ok || !isAdmin {
+			response.WriteJson(w, http.StatusForbidden, apperrors.ErrAccessForbidden.Error(), nil)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/repository/base.go
+++ b/internal/repository/base.go
@@ -22,6 +22,7 @@ type RepositoryTransaction interface {
 
 type QueryExecuter interface {
 	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
 }
 

--- a/internal/repository/domain.go
+++ b/internal/repository/domain.go
@@ -29,3 +29,24 @@ type CreateUserRequestBody struct {
 	Email          string
 	IsAdmin        bool
 }
+
+type ContributionScore struct {
+	Id               int
+	AdminId          int
+	ContributionType string
+	Score            int
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
+}
+
+type LeaderboardEntry struct {
+	Id             int
+	UserId         int
+	GithubId       int
+	AvatarUrl      string
+	CurrentBalance int
+	Rank           int
+	RefreshedAt    time.Time
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -21,6 +21,10 @@ type UserRepository interface {
 	GetUserByGithubId(ctx context.Context, tx *sqlx.Tx, githubId int) (User, error)
 	CreateUser(ctx context.Context, tx *sqlx.Tx, userInfo CreateUserRequestBody) (User, error)
 	UpdateUserEmail(ctx context.Context, tx *sqlx.Tx, userId int, email string) error
+	ListContributionScores(ctx context.Context, tx *sqlx.Tx) ([]ContributionScore, error)
+	UpdateContributionScore(ctx context.Context, tx *sqlx.Tx, contributionScoreId int, score int) error
+	ListLeaderboard(ctx context.Context, tx *sqlx.Tx) ([]LeaderboardEntry, error)
+	UpdateUserBlocked(ctx context.Context, tx *sqlx.Tx, userId int, isBlocked bool) error
 }
 
 func NewUserRepository(db *sqlx.DB) UserRepository {
@@ -45,6 +49,10 @@ const (
 	RETURNING *`
 
 	updateEmailQuery = "UPDATE users SET email=$1, updated_at=$2 where id=$3"
+	listContributionScoresQuery = "SELECT id, admin_id, contribution_type, score, created_at, updated_at FROM contribution_score ORDER BY contribution_type"
+	updateContributionScoreQuery = "UPDATE contribution_score SET score=$1, updated_at=$2 WHERE id=$3"
+	listLeaderboardQuery = "SELECT id, user_id, github_id, avatar_url, current_balance, rank, refreshed_at, created_at, updated_at FROM leaderboard_hourly WHERE refreshed_at = (SELECT MAX(refreshed_at) FROM leaderboard_hourly) ORDER BY rank"
+	updateUserBlockedQuery = "UPDATE users SET is_blocked=$1, updated_at=$2 WHERE id=$3 AND is_admin=FALSE"
 )
 
 func (ur *userRepository) GetUserById(ctx context.Context, tx *sqlx.Tx, userId int) (User, error) {
@@ -152,6 +160,121 @@ func (ur *userRepository) UpdateUserEmail(ctx context.Context, tx *sqlx.Tx, user
 	if err != nil {
 		slog.Error("failed to update user email", "error", err)
 		return apperrors.ErrInternalServer
+	}
+
+	return nil
+}
+
+func (ur *userRepository) ListContributionScores(ctx context.Context, tx *sqlx.Tx) ([]ContributionScore, error) {
+	executer := ur.BaseRepository.initiateQueryExecuter(tx)
+
+	rows, err := executer.QueryContext(ctx, listContributionScoresQuery)
+	if err != nil {
+		slog.Error("failed to list contribution scores", "error", err)
+		return nil, apperrors.ErrInternalServer
+	}
+	defer rows.Close()
+
+	contributionScores := []ContributionScore{}
+	for rows.Next() {
+		var contributionScore ContributionScore
+		err = rows.Scan(
+			&contributionScore.Id,
+			&contributionScore.AdminId,
+			&contributionScore.ContributionType,
+			&contributionScore.Score,
+			&contributionScore.CreatedAt,
+			&contributionScore.UpdatedAt,
+		)
+		if err != nil {
+			slog.Error("failed to scan contribution score", "error", err)
+			return nil, apperrors.ErrInternalServer
+		}
+		contributionScores = append(contributionScores, contributionScore)
+	}
+	if err = rows.Err(); err != nil {
+		slog.Error("failed to read contribution scores", "error", err)
+		return nil, apperrors.ErrInternalServer
+	}
+
+	return contributionScores, nil
+}
+
+func (ur *userRepository) UpdateContributionScore(ctx context.Context, tx *sqlx.Tx, contributionScoreId int, score int) error {
+	executer := ur.BaseRepository.initiateQueryExecuter(tx)
+
+	result, err := executer.ExecContext(ctx, updateContributionScoreQuery, score, time.Now(), contributionScoreId)
+	if err != nil {
+		slog.Error("failed to update contribution score", "error", err)
+		return apperrors.ErrInternalServer
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		slog.Error("failed to check updated contribution score", "error", err)
+		return apperrors.ErrInternalServer
+	}
+	if rowsAffected == 0 {
+		return apperrors.ErrInvalidQueryParams
+	}
+
+	return nil
+}
+
+func (ur *userRepository) ListLeaderboard(ctx context.Context, tx *sqlx.Tx) ([]LeaderboardEntry, error) {
+	executer := ur.BaseRepository.initiateQueryExecuter(tx)
+
+	rows, err := executer.QueryContext(ctx, listLeaderboardQuery)
+	if err != nil {
+		slog.Error("failed to list leaderboard", "error", err)
+		return nil, apperrors.ErrInternalServer
+	}
+	defer rows.Close()
+
+	leaderboard := []LeaderboardEntry{}
+	for rows.Next() {
+		var leaderboardEntry LeaderboardEntry
+		err = rows.Scan(
+			&leaderboardEntry.Id,
+			&leaderboardEntry.UserId,
+			&leaderboardEntry.GithubId,
+			&leaderboardEntry.AvatarUrl,
+			&leaderboardEntry.CurrentBalance,
+			&leaderboardEntry.Rank,
+			&leaderboardEntry.RefreshedAt,
+			&leaderboardEntry.CreatedAt,
+			&leaderboardEntry.UpdatedAt,
+		)
+		if err != nil {
+			slog.Error("failed to scan leaderboard", "error", err)
+			return nil, apperrors.ErrInternalServer
+		}
+		leaderboard = append(leaderboard, leaderboardEntry)
+	}
+	if err = rows.Err(); err != nil {
+		slog.Error("failed to read leaderboard", "error", err)
+		return nil, apperrors.ErrInternalServer
+	}
+
+	return leaderboard, nil
+}
+
+func (ur *userRepository) UpdateUserBlocked(ctx context.Context, tx *sqlx.Tx, userId int, isBlocked bool) error {
+	executer := ur.BaseRepository.initiateQueryExecuter(tx)
+
+	result, err := executer.ExecContext(ctx, updateUserBlockedQuery, isBlocked, time.Now(), userId)
+	if err != nil {
+		slog.Error("failed to update user blocked status", "error", err)
+		return apperrors.ErrInternalServer
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		slog.Error("failed to check updated user blocked status", "error", err)
+		return apperrors.ErrInternalServer
+	}
+	if rowsAffected == 0 {
+		return apperrors.ErrUserNotFound
 	}
 
 	return nil


### PR DESCRIPTION
# Summary

- Issue 27 : Implement Admin Panel
- Added hardcoded admin login with JWT
- Added admin-only APIs for contribution score config, leaderboard view, and user block/unblock
- Added local env sample
- Fixed local config loading for `.env.local`
- Fixed migration command panic when no step argument is passed

# Testing
- Ran local Postgres via Docker
- Ran migrations
- Verified health endpoint: `GET /api/v1/health`
- Tested admin login and admin endpoints via API client
